### PR TITLE
fix: resolve ModuleNotFoundError when running without pip install

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,5 @@
+# Add src to path for local development without pip install
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))


### PR DESCRIPTION
## Problem
Users running  directly without installing the package get:


## Solution
Add  that adds  to Python path, enabling local imports without needing to run .

## Testing
This fix allows the app to run in environments where the package is not installed, such as Google Colab or fresh clones of the repository.

Closes #46